### PR TITLE
Update README example

### DIFF
--- a/.changeset/khaki-dolphins-work.md
+++ b/.changeset/khaki-dolphins-work.md
@@ -1,0 +1,5 @@
+---
+"effect-vscode": patch
+---
+
+Document minimum required node version with Websocket support

--- a/.changeset/khaki-dolphins-work.md
+++ b/.changeset/khaki-dolphins-work.md
@@ -2,4 +2,4 @@
 "effect-vscode": patch
 ---
 
-Document minimum required node version with Websocket support
+Update README.md example

--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ You can then import and use the `DevTools` module in your Effect app:
 
 ```ts
 import { DevTools } from "@effect/experimental"
+import { NodeRuntime, NodeSocket } from "@effect/platform-node"
 import { Effect, Layer } from "effect"
 
-const program = Effect.sleep("1 seconds").pipe(Effect.withSpan("hello world"))
+const program = Effect.log("Hello!").pipe(
+  Effect.delay(2000),
+  Effect.withSpan("Hi", { attributes: { foo: "bar" } }),
+  Effect.forever,
+)
+const DevToolsLive = DevTools.layerWebSocket().pipe(
+  Layer.provide(NodeSocket.layerWebSocketConstructor),
+)
 
-program.pipe(Effect.provide(DevTools.layer()), Effect.runFork)
+program.pipe(Effect.provide(DevToolsLive), NodeRuntime.runMain)
 ```
 
 If you are using `@effect/opentelemetry` in your project, then it is important that you provide the `DevTools` layer **before** your tracing layers, so the tracer is patched correctly.
@@ -28,5 +36,3 @@ If you are using `@effect/opentelemetry` in your project, then it is important t
 Once you have added the Layer to your project, open the Effect Dev Tools panel in vscode & click "Start the server" in the "Clients" panel.
 
 You can then start your Effect app, and then begin to inspect the results!
-
-> Requires node version `>=22` with support for `globalThis.WebSocket`

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ If you are using `@effect/opentelemetry` in your project, then it is important t
 Once you have added the Layer to your project, open the Effect Dev Tools panel in vscode & click "Start the server" in the "Clients" panel.
 
 You can then start your Effect app, and then begin to inspect the results!
+
+> Requires node version `>=22` with support for `globalThis.WebSocket`


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The DevTools library can't communicate with the vscode extension when used with Node versions that don't support the Websocket API. Include a note in the documentation so that users can switch to a supported Node version or provide their own implementation.
